### PR TITLE
Add an Atom feed of posts

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,3 +3,5 @@ baseurl: ""
 url: "http://www.peopleideasmachines.com"
 title: "People, Ideas, Machines"
 permalink: :title
+gems:
+  - jekyll-feed


### PR DESCRIPTION
The [jekyll-feed](https://github.com/jekyll/jekyll-feed) plugin generates an [Atom feed](https://en.wikipedia.org/wiki/Atom_(standard)) of posts at `/feed.xml`, which I can subscribe to from my RSS reader. 😄 